### PR TITLE
Install the extensions header files for external use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,9 @@ packageProject(
   COMPATIBILITY SameMajorVersion
 )
 
+install(DIRECTORY extension/include/
+  DESTINATION ${INCLUDE_INSTALL_DIR})
+
 option(BOOST_DI_OPT_BUILD_TESTS "Build and perform Boost::DI tests" ${IS_TOPLEVEL_PROJECT})
 if(BOOST_DI_OPT_BUILD_TESTS)
   enable_testing()


### PR DESCRIPTION
Problem:
- Extension header files don't get installed making it difficult to use this with ROS2 and ament.

Solution:
- Add an additional install() to CMakeLists.

Issue: #

Reviewers:
@